### PR TITLE
Update status code in meme generator requirements

### DIFF
--- a/projects/02-meme-generator-api/requirements.md
+++ b/projects/02-meme-generator-api/requirements.md
@@ -48,7 +48,7 @@ Request body
 
 Response: 
 
-When successful, the response status should be 307 (temporary redirect) and the redirect URL should be the URL of the generated image. 
+When successful, the response status should be 303 (See Other) and the redirect URL should be the URL of the generated image. 
 
 See in the `/examples` directory a simple sintra app that redirects to an image.
 


### PR DESCRIPTION
Reason is that a 307 status code makes the client retry the exact request (POST with Body) on the redirect location.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307

And we were interested to implement a GET /meme to read the image